### PR TITLE
Use constant `weight_to_fee` for XCM

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -92,6 +92,8 @@ pub const MICRO_COIN: Balance = 1_000 * G_WEI;
 pub const MILLI_COIN: Balance = 1_000 * MICRO_COIN;
 /// `1_000_000_000_000_000_000` in `u128`.
 pub const COIN: Balance = 1_000 * MILLI_COIN;
+/// Base balance required for the xcm unit weight
+pub const BASE_WEIGHT_FEE: Balance = G_WEI;
 
 /// Block time of Darwinia Parachain.
 pub const MILLISECS_PER_BLOCK: Moment = 12000;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -92,6 +92,7 @@ pub const MICRO_COIN: Balance = 1_000 * G_WEI;
 pub const MILLI_COIN: Balance = 1_000 * MICRO_COIN;
 /// `1_000_000_000_000_000_000` in `u128`.
 pub const COIN: Balance = 1_000 * MILLI_COIN;
+
 /// Base balance required for the xcm unit weight
 pub const BASE_WEIGHT_FEE: Balance = G_WEI;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -93,6 +93,9 @@ pub const MILLI_COIN: Balance = 1_000 * MICRO_COIN;
 /// `1_000_000_000_000_000_000` in `u128`.
 pub const COIN: Balance = 1_000 * MILLI_COIN;
 
+/// Balance required for the xcm unit weight
+pub const WEIGHT_FEE: Balance = G_WEI;
+
 /// Block time of Darwinia Parachain.
 pub const MILLISECS_PER_BLOCK: Moment = 12000;
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -93,9 +93,6 @@ pub const MILLI_COIN: Balance = 1_000 * MICRO_COIN;
 /// `1_000_000_000_000_000_000` in `u128`.
 pub const COIN: Balance = 1_000 * MILLI_COIN;
 
-/// Balance required for the xcm unit weight
-pub const WEIGHT_FEE: Balance = G_WEI;
-
 /// Block time of Darwinia Parachain.
 pub const MILLISECS_PER_BLOCK: Moment = 12000;
 

--- a/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
@@ -96,8 +96,6 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub const MaxInstructions: u32 = 100;
-	// Balance required for the xcm unit weight
-	pub const WEIGHT_FEE: Balance = 10 * G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))
@@ -137,7 +135,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = UsingComponents<
-		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE * 10 }>>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
@@ -135,7 +135,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = UsingComponents<
-		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE * 10 }>>,
+		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE }>>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
@@ -96,6 +96,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub const MaxInstructions: u32 = 100;
+	// Balance required for the xcm unit weight
+	pub const WEIGHT_FEE: Balance = 10 * G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))

--- a/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
@@ -3,9 +3,8 @@ use cumulus_pallet_xcm::Origin as CumulusOrigin;
 use cumulus_primitives_utility::ParentAsUmp;
 use frame_support::{
 	traits::{Everything, PalletInfoAccess},
-	weights::Weight,
+	weights::{ConstantMultiplier, Weight},
 };
-use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
@@ -135,8 +134,13 @@ impl XcmCExecutorConfig for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
-	type Trader =
-		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<
+		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		AnchoringSelfReserve,
+		AccountId,
+		Balances,
+		ToAuthor<Runtime>,
+	>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/crab-parachain/src/pallets/polkadot_xcm.rs
@@ -5,9 +5,11 @@ use frame_support::{
 	traits::{Everything, PalletInfoAccess},
 	weights::Weight,
 };
+use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
+use sp_runtime::traits::ConstU128;
 use xcm::latest::prelude::*;
 use xcm_builder::*;
 use xcm_executor::{Config as XcmCExecutorConfig, XcmExecutor};
@@ -134,7 +136,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader =
-		UsingComponents<WeightToFee, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
@@ -96,8 +96,6 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub const MaxInstructions: u32 = 100;
-	// Balance required for the xcm unit weight
-	pub const WEIGHT_FEE: Balance = G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))
@@ -137,7 +135,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = UsingComponents<
-		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE }>>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
@@ -3,9 +3,8 @@ use cumulus_pallet_xcm::Origin as CumulusOrigin;
 use cumulus_primitives_utility::ParentAsUmp;
 use frame_support::{
 	traits::{Everything, PalletInfoAccess},
-	weights::Weight,
+	weights::{ConstantMultiplier, Weight},
 };
-use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
@@ -135,8 +134,13 @@ impl XcmCExecutorConfig for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
-	type Trader =
-		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<
+		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		AnchoringSelfReserve,
+		AccountId,
+		Balances,
+		ToAuthor<Runtime>,
+	>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
@@ -96,6 +96,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub const MaxInstructions: u32 = 100;
+	// Balance required for the xcm unit weight
+	pub const WEIGHT_FEE: Balance = G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))

--- a/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/darwinia-parachain/src/pallets/polkadot_xcm.rs
@@ -5,9 +5,11 @@ use frame_support::{
 	traits::{Everything, PalletInfoAccess},
 	weights::Weight,
 };
+use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
+use sp_runtime::traits::ConstU128;
 use xcm::latest::prelude::*;
 use xcm_builder::*;
 use xcm_executor::{Config as XcmCExecutorConfig, XcmExecutor};
@@ -134,7 +136,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader =
-		UsingComponents<WeightToFee, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
@@ -96,8 +96,6 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub const MaxInstructions: u32 = 100;
-	// Balance required for the xcm unit weight
-	pub const WEIGHT_FEE: Balance = 10 * G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))
@@ -137,7 +135,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = UsingComponents<
-		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE * 10 }>>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
@@ -135,7 +135,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader = UsingComponents<
-		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE * 10 }>>,
+		ConstantMultiplier<Balance, ConstU128<{ BASE_WEIGHT_FEE }>>,
 		AnchoringSelfReserve,
 		AccountId,
 		Balances,

--- a/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
@@ -96,6 +96,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 frame_support::parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
 	pub const MaxInstructions: u32 = 100;
+	// Balance required for the xcm unit weight
+	pub const WEIGHT_FEE: Balance = 10 * G_WEI;
 	pub AnchoringSelfReserve: MultiLocation = MultiLocation::new(
 		0,
 		X1(PalletInstance(<Balances as PalletInfoAccess>::index() as u8))

--- a/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
@@ -3,9 +3,8 @@ use cumulus_pallet_xcm::Origin as CumulusOrigin;
 use cumulus_primitives_utility::ParentAsUmp;
 use frame_support::{
 	traits::{Everything, PalletInfoAccess},
-	weights::Weight,
+	weights::{ConstantMultiplier, Weight},
 };
-use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
@@ -135,8 +134,13 @@ impl XcmCExecutorConfig for XcmConfig {
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
-	type Trader =
-		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = UsingComponents<
+		ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>,
+		AnchoringSelfReserve,
+		AccountId,
+		Balances,
+		ToAuthor<Runtime>,
+	>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
+++ b/runtime/pangolin-parachain/src/pallets/polkadot_xcm.rs
@@ -5,9 +5,11 @@ use frame_support::{
 	traits::{Everything, PalletInfoAccess},
 	weights::Weight,
 };
+use frame_support::weights::ConstantMultiplier;
 use pallet_xcm::{Config, CurrentXcmVersion, XcmPassthrough};
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
+use sp_runtime::traits::ConstU128;
 use xcm::latest::prelude::*;
 use xcm_builder::*;
 use xcm_executor::{Config as XcmCExecutorConfig, XcmExecutor};
@@ -134,7 +136,7 @@ impl XcmCExecutorConfig for XcmConfig {
 	type ResponseHandler = PolkadotXcm;
 	type SubscriptionService = PolkadotXcm;
 	type Trader =
-		UsingComponents<WeightToFee, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
+		UsingComponents<ConstantMultiplier<Balance, ConstU128<WEIGHT_FEE>>, AnchoringSelfReserve, AccountId, Balances, ToAuthor<Runtime>>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type XcmSender = XcmRouter;
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -258,9 +258,7 @@ pub fn run() -> Result<()> {
 				.ok_or("Could not find parachain ID in chain-spec.")?;
 			let polkadot_cli = RelayChainCli::new(
 				&config,
-				[RelayChainCli::executable_name()]
-					.iter()
-					.chain(cli.relay_chain_args.iter()),
+				[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
 			);
 			let id = ParaId::from(para_id);
 			let parachain_account = AccountIdConversion::<AccountId>::into_account_truncating(&id);
@@ -346,9 +344,7 @@ pub fn run() -> Result<()> {
 			runner.sync_run(|config| {
 				let polkadot_cli = RelayChainCli::new(
 					&config,
-					[RelayChainCli::executable_name()]
-						.iter()
-						.chain(cli.relay_chain_args.iter()),
+					[RelayChainCli::executable_name()].iter().chain(cli.relay_chain_args.iter()),
 				);
 
 				let polkadot_config = SubstrateCli::create_configuration(


### PR DESCRIPTION
Simplify XCM `weight_to_fee`, making it more convenient to calculate XCM execution cost remotely.
After modification, 1 xcm instruction in darwinia-parachain cost 1RING ≈ 0.0065$, while moonbeam cost 0.01GLMR ≈ 0.0048$
```
darwinia parachain:
1 xcm instruction weight: 1_000_000_000
WEIGHT_FEE: 1_000_000_000 UNIT RING
FEE: 1_000_000_000_000_000_000 UNIT = 1 RING ≈ 0.0065$
---
moonbeam:
1 xcm instruction weight = 200_000_000
WEIGHT_FEE: 5_000_000 UNIT GLMR
FEE: 1_000_000_000_000_000 UNIT = 0.01GLMR ≈ 0.0048$
```
Refer to Moonbeam:
https://github.com/PureStake/moonbeam/blob/master/runtime/moonbase/src/xcm_config.rs#L281
https://github.com/PureStake/substrate/blob/moonbeam-polkadot-v0.9.26/frame/support/src/weights.rs#L741

Refer to Acala:
https://github.com/AcalaNetwork/Acala/blob/master/runtime/acala/src/xcm_config.rs#L148
https://github.com/paritytech/polkadot/blob/master/xcm/xcm-builder/src/weight.rs#L207